### PR TITLE
[Fix #2] Fix download link and Hugo errors

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,7 @@ pluralizeListTitles = false
   gcse_result_url = "https://www.eclipse.org/home/search/"
   header_wrapper_class = "header_wrapper_class"
   call_for_action_text = "Download"
-  call_for_action_url = "download"
+  call_for_action_url = "/mat/download"
   call_for_action_icon = "fa-download"
   layout_style = "astro"
   hide_ad = false
@@ -36,19 +36,18 @@ pluralizeListTitles = false
 # table_classes = "table table-bordered"
 # hide_cfa_same_page = true
 # show_collapsible_menu = true
+  [Params.Author]
+    name = "Eclipse Foundation"
+    website = "https://www.eclipse.org"
+    email = "webdev@eclipse-foundation.org"
+    facebook = "eclipse.org"
+    twitter = "eclipsefdn"
+    youtube = "EclipseFdn"
+    googleplus = "+Eclipse"
+    linkedin = "company/eclipse-foundation/"
 
 [taxonomies]
   tag = "tags"
-
-[Author]
-  name = "Eclipse Foundation"
-  website = "https://www.eclipse.org"
-  email = "webdev@eclipse-foundation.org"
-  facebook = "eclipse.org"
-  twitter = "eclipsefdn"
-  youtube = "EclipseFdn"
-  googleplus = "+Eclipse"
-  linkedin = "company/eclipse-foundation/"
 
 [permalinks]
   news = "/:sections/:year/:month/:day/:slug/"

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Memory Analyzer (MAT)"
-date: 2025-01-10T10:00:00+2:00
+date: 2025-01-10T10:00:00+02:00
 #headline: "The Community for Open Innovation and Collaboration"
 #tagline: "The Eclipse Foundation provides our global community of individuals and organizations with a mature, scalable, and business-friendly environment for open source software collaboration and innovation."
 hide_page_title: true

--- a/content/documentation/_index.md
+++ b/content/documentation/_index.md
@@ -2,7 +2,7 @@
 title: "Memory Analyzer Documentation Resources"
 seo_title: "Documentation"
 description: "A collection of documentation resources about Memory Analyzer"
-date: 2024-12-18T12:00:00+2:00
+date: 2024-12-18T12:00:00+02:00
 layout: "single"
 ---
 

--- a/content/download/_index.md
+++ b/content/download/_index.md
@@ -2,7 +2,7 @@
 title: "Downloads"
 seo_title: "Downloads"
 description: "Memory Analyzer Downloads"
-date: 2025-01-10T10:00:00+2:00
+date: 2025-01-10T10:00:00+02:00
 layout: "single"
 ---
 

--- a/content/download/previous.md
+++ b/content/download/previous.md
@@ -2,7 +2,7 @@
 title: "Previous Releases"
 seo_title: "Previous Releases"
 description: "This is an example of the Eclipse Foundation Solstice theme for Hugo."
-date: 2025-01-10T10:00:00+2:00
+date: 2025-01-10T10:00:00+02:00
 layout: "single"
 ---
 


### PR DESCRIPTION
Using the latest Hugo, I couldn't start it without fixing these errors:

```
ERROR the "date" front matter field is not a parsable date: see /Users/kevin/git/website/content/_index.md
ERROR the "date" front matter field is not a parsable date: see /Users/kevin/git/website/content/documentation/_index.md
ERROR the "date" front matter field is not a parsable date: see /Users/kevin/git/website/content/download/_index.md
ERROR the "date" front matter field is not a parsable date: see /Users/kevin/git/website/content/download/previous.md
ERROR deprecated: .Site.Author was deprecated in Hugo v0.124.0 and subsequently removed. Implement taxonomy 'author' or use .Site.Params.Author instead.
```